### PR TITLE
fix(rpc): fix the rpc transaction data structure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
     rev: main
     hooks:
     -   id: gitlint
-- repo: git://github.com/dnephin/pre-commit-golang
+- repo: git://github.com/soyoslab/pre-commit-golang
   rev: master
   hooks:
     - id: go-fmt

--- a/pkg/rpc/type.go
+++ b/pkg/rpc/type.go
@@ -3,23 +3,34 @@ package rpc
 // LogInfo is part of LogMessage.
 // Consist of timestamp, filename, length.
 // timestamp is the time log created.
-// filename is the name of log file.
 // length is the size(bytes) per log message.
 type LogInfo struct {
 	Timestamp int64
-	Filename  string
 	Length    uint64
 }
 
+// LogFile is part of LogMessage.
+// Consist of maptable, indexes.
+// maptable's key is filename and value is filename identifier.
+// indexes contains filename identifier is defined MapTable.
+type LogFile struct {
+	MapTable []string
+	Indexes  []uint8
+}
+
 // LogMessage is rpc parameter type with soy_log_generator.
-// Consist of info, buffer.
+// Consist of namespace, files, info, buffer.
+// namespace is container's namespace.
+// files contains the LogFile structure information/
 // info is log information array.
 // buffer is sequence of byte data.
 // Compacted when used for ColdPort,
 // Should not compacted when used for HotPort.
 type LogMessage struct {
-	Info   []LogInfo
-	Buffer []byte
+	Namespace string
+	Files     LogFile
+	Info      []LogInfo
+	Buffer    []byte
 }
 
 // Reply is for Communication with rpc caller.


### PR DESCRIPTION
Fixed the rpc transaction data structure(located in `pkg/rpc/type.go`).
LogMessage's member Namespace and Files added.

Former contains the information of the namespace of the generator.
More specifically, it can be defined by user.

Latter has the information of files to send. MapTable's indexes can be
used as key to find the filename fast. In other words, MapTable's values
are filenames. Next, Indexes is contains the sequence of the files in the
data. It does not have the filename as string but it has filename as
integer which is defined in the MapTable. Sample example is like below.

```
Files.MapTable = ["sample1.txt", "sample2.txt"]
// Timestamp field is ignored
LogInfo = [{"length": 10}, {"length": 20}, {"length": 30}]
Files.Indexes = [0, 1, 0]
// First index means "sample1.txt file data length 10"
// Second index means "sample2.txt file data length 20"
// Third index means "sample3.txt file data length 30"
```

NOTE THAT, You must take care of the Indexes' per type is uint8. That
means, you cannot add the file over 256.